### PR TITLE
Add consent-based remote desktop MVP (Windows host)

### DIFF
--- a/.github/workflows/remote-desktop-ci.yml
+++ b/.github/workflows/remote-desktop-ci.yml
@@ -1,0 +1,52 @@
+name: Remote Desktop CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'remote-desktop/**'
+      - '.github/workflows/remote-desktop-ci.yml'
+  pull_request:
+    paths:
+      - 'remote-desktop/**'
+      - '.github/workflows/remote-desktop-ci.yml'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [signaling, host, viewer]
+    defaults:
+      run:
+        working-directory: remote-desktop/${{ matrix.app }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      # --ignore-scripts skips nut-js's native build (needs MSVC on Windows).
+      # We only want to validate that package.json resolves.
+      - name: Install deps (no scripts)
+        run: npm install --ignore-scripts --no-audit --no-fund
+
+      - name: Syntax check all JS/CJS files
+        shell: bash
+        run: |
+          set -e
+          fail=0
+          while IFS= read -r -d '' f; do
+            case "$f" in
+              */node_modules/*) continue ;;
+            esac
+            # .cjs = CommonJS, .js honours the package.json "type" field.
+            if ! node --check "$f"; then
+              echo "::error file=$f::syntax error"
+              fail=1
+            fi
+          done < <(find . -type f \( -name '*.js' -o -name '*.cjs' -o -name '*.mjs' \) -print0)
+          exit $fail

--- a/remote-desktop/.gitignore
+++ b/remote-desktop/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+package-lock.json
+dist/
+out/
+*.log

--- a/remote-desktop/README.md
+++ b/remote-desktop/README.md
@@ -1,0 +1,127 @@
+# Remote Desktop (Windows MVP)
+
+Consent-based remote desktop tool, modelled on how AnyDesk / TeamViewer /
+Chrome Remote Desktop work. The person being controlled (the **host**) must
+explicitly share a session ID + one-time passcode and then click **Accept**
+before any viewer can see their screen, and a red banner stays on-screen for
+the duration of the session.
+
+This is an MVP. It is **not** a drop-in AnyDesk replacement — see
+[Limitations](#limitations).
+
+## Architecture
+
+```
+  Host (Windows)                 Signaling server                 Viewer
+  ─────────────                  ────────────────                  ──────
+  Electron app          ──WS──►  Node + ws         ◄──WS──        Electron app
+  (screen capture,               (pairs a host and                 (displays remote
+   input injection via           a viewer by                        screen, forwards
+   nut-js, consent UI)           session ID +                       mouse / keyboard)
+                                 passcode hash)
+            ◄──────── WebRTC (video + "input" data channel) ────────►
+```
+
+* Video is sent host → viewer over a WebRTC peer connection.
+* Mouse / keyboard events are sent viewer → host over a WebRTC data channel
+  (`label: "input"`).
+* The signaling server only relays JSON and sees the SHA-256 hash of the
+  passcode, never the plaintext.
+* STUN is Google's public server; add a TURN server if you need to traverse
+  strict NATs.
+
+See [`shared/protocol.md`](shared/protocol.md) for the message schema.
+
+## Consent model (non-negotiable)
+
+1. Every session generates a fresh 9-digit session ID and 6-digit passcode.
+2. When a viewer connects with a valid ID + passcode, the host sees an
+   "Incoming connection request" dialog and must click **Accept**.
+3. While a session is active, a red banner is visible in the host app
+   ("⚠ Your screen is being viewed and controlled right now") with an
+   **End session** button.
+4. There is no silent mode, no auto-accept, no persistent backdoor, no
+   auto-start-at-boot. Do not add them. Using this tool to access a
+   computer without the owner's knowledge and permission is illegal in
+   most jurisdictions.
+
+## Setup on Windows
+
+Requirements:
+
+* Node.js 20 or newer (https://nodejs.org)
+* Windows 10 / 11
+* Visual Studio Build Tools (C++ workload) — `nut-js` has native deps that
+  build on first `npm install`. Easiest: `npm install --global windows-build-tools`
+  once, or install "Desktop development with C++" via the Visual Studio
+  Installer.
+
+Install deps for all three apps:
+
+```powershell
+cd remote-desktop\signaling ; npm install
+cd ..\host                  ; npm install
+cd ..\viewer                ; npm install
+```
+
+### Run the signaling server
+
+On a machine reachable from both the host and the viewer (your own laptop is
+fine for same-LAN testing; otherwise a small VPS):
+
+```powershell
+cd remote-desktop\signaling
+npm start
+# [signaling] listening on ws://0.0.0.0:8443
+```
+
+For anything other than `localhost` testing you **must** put this behind TLS
+(nginx / Caddy with a real cert) and use `wss://` — the passcode hash and
+SDP go over this connection.
+
+### Run the host (on the machine being controlled)
+
+```powershell
+cd remote-desktop\host
+$env:SIGNALING_URL = "ws://<signaling-host>:8443"   # omit for localhost
+npm start
+```
+
+The host window shows a session ID and passcode. Read them to the other
+person out-of-band (phone, Signal, etc.).
+
+### Run the viewer
+
+```powershell
+cd remote-desktop\viewer
+$env:SIGNALING_URL = "ws://<signaling-host>:8443"
+npm start
+```
+
+Enter the ID + passcode, click Connect, and wait for the host to Accept.
+Once the video appears, click inside it to give it focus, then your mouse
+and keyboard will be forwarded to the host machine.
+
+## Limitations
+
+* **Windows-only host.** `nut-js` works on macOS and Linux too but the
+  key-code map in `host/src/main.js` is only tested on Windows.
+* **Single primary monitor.** Multi-monitor support would add a source
+  picker.
+* **No audio**, no file transfer, no clipboard sync.
+* **No TURN server configured.** Direct-NAT scenarios will fail; you need
+  to add TURN credentials to `ICE_SERVERS` in both renderers.
+* **Elevated (UAC) windows** will not receive input unless the host
+  Electron process is itself running as Administrator, because Windows
+  blocks cross-integrity-level input injection.
+* **Not hardened for production.** No rate limiting, no brute-force
+  protection on the passcode (6 digits = 1M keys; rotate per session and
+  keep sessions short). Add lockout + TLS + auth before exposing the
+  signaling server to the public internet.
+
+## What's intentionally not here
+
+No unattended / always-on mode. No service installer. No hidden-window
+mode. No mechanism to bypass the Accept dialog. These are the features
+that turn a legitimate remote-support tool into malware; if you need them
+for a real use case, use a commercial product with proper audit logging.

--- a/remote-desktop/host/package.json
+++ b/remote-desktop/host/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "remote-desktop-host",
+  "version": "0.1.0",
+  "description": "Windows host app: captures the screen, requires explicit consent for every connection, and applies remote input via nut-js.",
+  "type": "module",
+  "main": "src/main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^33.0.0"
+  },
+  "dependencies": {
+    "@nut-tree-fork/nut-js": "^4.2.2",
+    "ws": "^8.18.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/remote-desktop/host/src/main.js
+++ b/remote-desktop/host/src/main.js
@@ -1,0 +1,202 @@
+import { app, BrowserWindow, ipcMain, desktopCapturer, screen } from "electron";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { createHash, randomInt } from "node:crypto";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Lazy-load nut-js so the app still starts on machines where the optional
+// native deps failed to build; input injection will just no-op in that case.
+let nut = null;
+async function loadNut() {
+  if (nut) return nut;
+  try {
+    nut = await import("@nut-tree-fork/nut-js");
+    nut.keyboard.config.autoDelayMs = 0;
+    nut.mouse.config.autoDelayMs = 0;
+    return nut;
+  } catch (err) {
+    console.error("[host] nut-js unavailable, input injection disabled:", err);
+    nut = { disabled: true };
+    return nut;
+  }
+}
+
+const SIGNALING_URL =
+  process.env.SIGNALING_URL || "ws://localhost:8443";
+
+function sha256Hex(s) {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+function newPasscode() {
+  // 6 digits, zero-padded.
+  return String(randomInt(0, 1_000_000)).padStart(6, "0");
+}
+
+let mainWindow = null;
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 520,
+    height: 640,
+    resizable: false,
+    title: "Remote Desktop Host",
+    webPreferences: {
+      preload: path.join(__dirname, "preload.cjs"),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+  mainWindow.loadFile(path.join(__dirname, "renderer.html"));
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  app.on("activate", () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") app.quit();
+});
+
+// ---------------------------------------------------------------------------
+// IPC bridge used by the renderer (which owns the WebRTC peer connection)
+// ---------------------------------------------------------------------------
+
+ipcMain.handle("host:new-credentials", () => {
+  const passcode = newPasscode();
+  return { passcode, passcodeHash: sha256Hex(passcode) };
+});
+
+ipcMain.handle("host:signaling-url", () => SIGNALING_URL);
+
+ipcMain.handle("host:list-sources", async () => {
+  const sources = await desktopCapturer.getSources({
+    types: ["screen"],
+    thumbnailSize: { width: 160, height: 90 },
+  });
+  return sources.map((s) => ({
+    id: s.id,
+    name: s.name,
+    thumbnail: s.thumbnail.toDataURL(),
+  }));
+});
+
+ipcMain.handle("host:primary-display-size", () => {
+  const d = screen.getPrimaryDisplay();
+  return { width: d.size.width, height: d.size.height };
+});
+
+// ---------------------------------------------------------------------------
+// Input injection. Called from the renderer when a message arrives on the
+// "input" data channel from the viewer. All coordinates the viewer sends are
+// normalized to [0, 1] against the captured display size; we denormalize here.
+// ---------------------------------------------------------------------------
+
+const BUTTON_MAP = () => ({
+  left: nut.Button.LEFT,
+  right: nut.Button.RIGHT,
+  middle: nut.Button.MIDDLE,
+});
+
+ipcMain.handle("host:inject", async (_evt, event) => {
+  await loadNut();
+  if (nut.disabled) return { ok: false, reason: "nut-js unavailable" };
+
+  try {
+    switch (event.type) {
+      case "mouse-move": {
+        const d = screen.getPrimaryDisplay().size;
+        const x = Math.round(event.xNorm * d.width);
+        const y = Math.round(event.yNorm * d.height);
+        await nut.mouse.setPosition(new nut.Point(x, y));
+        break;
+      }
+      case "mouse-button": {
+        const btn = BUTTON_MAP()[event.button];
+        if (btn == null) break;
+        if (event.state === "down") await nut.mouse.pressButton(btn);
+        else await nut.mouse.releaseButton(btn);
+        break;
+      }
+      case "mouse-wheel": {
+        if (event.dy) {
+          if (event.dy > 0) await nut.mouse.scrollDown(Math.abs(event.dy));
+          else await nut.mouse.scrollUp(Math.abs(event.dy));
+        }
+        if (event.dx) {
+          if (event.dx > 0) await nut.mouse.scrollRight(Math.abs(event.dx));
+          else await nut.mouse.scrollLeft(Math.abs(event.dx));
+        }
+        break;
+      }
+      case "key": {
+        const key = codeToNutKey(event.code, nut);
+        if (key == null) break;
+        if (event.state === "down") await nut.keyboard.pressKey(key);
+        else await nut.keyboard.releaseKey(key);
+        break;
+      }
+      case "text": {
+        await nut.keyboard.type(String(event.value ?? ""));
+        break;
+      }
+    }
+    return { ok: true };
+  } catch (err) {
+    console.error("[host] inject failed:", err);
+    return { ok: false, reason: String(err) };
+  }
+});
+
+// Map a DOM KeyboardEvent.code to a nut-js Key enum value. Covers the common
+// cases; unknown codes are dropped rather than guessed.
+function codeToNutKey(code, nut) {
+  const K = nut.Key;
+  if (!code) return null;
+  if (/^Key[A-Z]$/.test(code)) return K[code.slice(3)];
+  if (/^Digit[0-9]$/.test(code)) return K["Num" + code.slice(5)];
+  if (/^Numpad[0-9]$/.test(code)) return K["NumPad" + code.slice(6)];
+  if (/^F([1-9]|1[0-9]|2[0-4])$/.test(code)) return K[code];
+  const direct = {
+    Enter: K.Enter,
+    Escape: K.Escape,
+    Backspace: K.Backspace,
+    Tab: K.Tab,
+    Space: K.Space,
+    ArrowUp: K.Up,
+    ArrowDown: K.Down,
+    ArrowLeft: K.Left,
+    ArrowRight: K.Right,
+    Home: K.Home,
+    End: K.End,
+    PageUp: K.PageUp,
+    PageDown: K.PageDown,
+    Delete: K.Delete,
+    Insert: K.Insert,
+    ShiftLeft: K.LeftShift,
+    ShiftRight: K.RightShift,
+    ControlLeft: K.LeftControl,
+    ControlRight: K.RightControl,
+    AltLeft: K.LeftAlt,
+    AltRight: K.RightAlt,
+    MetaLeft: K.LeftSuper,
+    MetaRight: K.RightSuper,
+    CapsLock: K.CapsLock,
+    Minus: K.Minus,
+    Equal: K.Equal,
+    BracketLeft: K.LeftBracket,
+    BracketRight: K.RightBracket,
+    Backslash: K.Backslash,
+    Semicolon: K.Semicolon,
+    Quote: K.Quote,
+    Comma: K.Comma,
+    Period: K.Period,
+    Slash: K.Slash,
+    Backquote: K.Grave,
+  };
+  return direct[code] ?? null;
+}

--- a/remote-desktop/host/src/preload.cjs
+++ b/remote-desktop/host/src/preload.cjs
@@ -1,0 +1,9 @@
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("hostAPI", {
+  newCredentials: () => ipcRenderer.invoke("host:new-credentials"),
+  signalingUrl: () => ipcRenderer.invoke("host:signaling-url"),
+  listSources: () => ipcRenderer.invoke("host:list-sources"),
+  primaryDisplaySize: () => ipcRenderer.invoke("host:primary-display-size"),
+  inject: (event) => ipcRenderer.invoke("host:inject", event),
+});

--- a/remote-desktop/host/src/renderer.html
+++ b/remote-desktop/host/src/renderer.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Remote Desktop Host</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: system-ui, sans-serif;
+      }
+      body {
+        margin: 0;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+      h1 { font-size: 18px; margin: 0; }
+      .card {
+        border: 1px solid #8884;
+        border-radius: 10px;
+        padding: 16px;
+      }
+      .id {
+        font-family: ui-monospace, Menlo, Consolas, monospace;
+        font-size: 36px;
+        letter-spacing: 4px;
+        text-align: center;
+        user-select: all;
+      }
+      .passcode {
+        font-family: ui-monospace, Menlo, Consolas, monospace;
+        font-size: 28px;
+        text-align: center;
+        user-select: all;
+      }
+      .status {
+        font-size: 13px;
+        opacity: 0.75;
+      }
+      .approve-box {
+        background: #ffb3;
+        border: 1px solid #c80;
+        padding: 12px;
+        border-radius: 8px;
+      }
+      .active-banner {
+        background: #c00;
+        color: white;
+        padding: 8px 12px;
+        border-radius: 6px;
+        font-weight: 600;
+      }
+      button {
+        font-size: 14px;
+        padding: 8px 14px;
+        border-radius: 6px;
+        border: 1px solid #8884;
+        background: #fff2;
+        cursor: pointer;
+      }
+      button.primary { background: #2a7; color: white; border-color: #2a7; }
+      button.danger { background: #c33; color: white; border-color: #c33; }
+      .row { display: flex; gap: 8px; }
+    </style>
+  </head>
+  <body>
+    <h1>Remote Desktop &mdash; Host</h1>
+
+    <div class="card">
+      <div class="status">Share this ID and one-time passcode with the person who should view your screen. A new passcode is generated every session.</div>
+      <div style="margin-top: 12px">Your session ID</div>
+      <div class="id" id="session-id">&mdash;</div>
+      <div style="margin-top: 12px">One-time passcode</div>
+      <div class="passcode" id="passcode">&mdash;</div>
+      <div class="status" id="conn-status" style="margin-top: 12px">Connecting to signaling server&hellip;</div>
+    </div>
+
+    <div class="card approve-box" id="approve-box" style="display:none">
+      <div><strong>Incoming connection request</strong></div>
+      <div class="status" id="approve-detail"></div>
+      <div class="row" style="margin-top: 12px">
+        <button class="primary" id="btn-accept">Accept</button>
+        <button class="danger" id="btn-reject">Reject</button>
+      </div>
+    </div>
+
+    <div class="card active-banner" id="active-banner" style="display:none">
+      ⚠ Your screen is being viewed and controlled right now.
+      <button class="danger" id="btn-end" style="margin-left: 12px">End session</button>
+    </div>
+
+    <script type="module" src="./renderer.js"></script>
+  </body>
+</html>

--- a/remote-desktop/host/src/renderer.js
+++ b/remote-desktop/host/src/renderer.js
@@ -1,0 +1,214 @@
+// Renderer-side of the host app. Owns the WebSocket signaling connection and
+// the WebRTC peer connection. Input events arriving on the data channel are
+// forwarded to the main process via `window.hostAPI.inject`, which applies
+// them with nut-js.
+
+const $ = (id) => document.getElementById(id);
+
+const state = {
+  ws: null,
+  pc: null,
+  inputChannel: null,
+  sessionId: null,
+  passcode: null,
+  pendingViewer: null,
+  screenStream: null,
+};
+
+const ICE_SERVERS = [{ urls: "stun:stun.l.google.com:19302" }];
+
+async function boot() {
+  const { passcode, passcodeHash } = await window.hostAPI.newCredentials();
+  state.passcode = passcode;
+  $("passcode").textContent = passcode.replace(/(\d{3})(\d{3})/, "$1 $2");
+
+  const url = await window.hostAPI.signalingUrl();
+  const ws = new WebSocket(url);
+  state.ws = ws;
+
+  ws.addEventListener("open", () => {
+    setStatus("Connected. Registering session…");
+    ws.send(JSON.stringify({ type: "host-register", passcodeHash }));
+  });
+
+  ws.addEventListener("message", (evt) => {
+    const msg = JSON.parse(evt.data);
+    handleSignal(msg);
+  });
+
+  ws.addEventListener("close", () => setStatus("Signaling connection closed."));
+  ws.addEventListener("error", () => setStatus("Signaling connection error."));
+}
+
+function setStatus(text) {
+  $("conn-status").textContent = text;
+}
+
+function formatSessionId(id) {
+  return id.replace(/(\d{3})(\d{3})(\d{3})/, "$1 $2 $3");
+}
+
+async function handleSignal(msg) {
+  switch (msg.type) {
+    case "host-registered":
+      state.sessionId = msg.sessionId;
+      $("session-id").textContent = formatSessionId(msg.sessionId);
+      setStatus("Waiting for a viewer to connect.");
+      break;
+
+    case "join-request":
+      state.pendingViewer = msg;
+      $("approve-box").style.display = "block";
+      $("approve-detail").textContent =
+        `Viewer "${msg.viewerLabel}" (${msg.viewerNonce}) wants to view and control this computer.`;
+      break;
+
+    case "viewer-disconnected":
+      teardownPeer();
+      setStatus("Viewer disconnected. Waiting for a new viewer.");
+      $("active-banner").style.display = "none";
+      break;
+
+    case "signal":
+      await handleWebRTCSignal(msg.payload);
+      break;
+
+    case "session-closed":
+      teardownPeer();
+      setStatus("Session closed: " + msg.reason);
+      $("active-banner").style.display = "none";
+      break;
+
+    case "error":
+      setStatus("Signaling error: " + msg.error);
+      break;
+  }
+}
+
+$("btn-accept").addEventListener("click", async () => {
+  if (!state.pendingViewer) return;
+  $("approve-box").style.display = "none";
+  state.ws.send(JSON.stringify({ type: "host-decision", accept: true }));
+  await startPeer();
+  $("active-banner").style.display = "block";
+});
+
+$("btn-reject").addEventListener("click", () => {
+  state.ws.send(JSON.stringify({ type: "host-decision", accept: false }));
+  state.pendingViewer = null;
+  $("approve-box").style.display = "none";
+});
+
+$("btn-end").addEventListener("click", () => {
+  state.ws.send(JSON.stringify({ type: "end-session" }));
+  teardownPeer();
+  $("active-banner").style.display = "none";
+  setStatus("Session ended by host.");
+});
+
+async function startPeer() {
+  const sources = await window.hostAPI.listSources();
+  if (!sources.length) {
+    setStatus("No screens available to capture.");
+    return;
+  }
+  // Capture the primary screen. Multi-monitor picker is left as a follow-up.
+  const sourceId = sources[0].id;
+
+  // The desktopCapturer-backed getUserMedia API expects this legacy shape.
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: false,
+    video: {
+      mandatory: {
+        chromeMediaSource: "desktop",
+        chromeMediaSourceId: sourceId,
+        maxWidth: 1920,
+        maxHeight: 1080,
+        maxFrameRate: 30,
+      },
+    },
+  });
+  state.screenStream = stream;
+
+  const pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+  state.pc = pc;
+  for (const track of stream.getTracks()) pc.addTrack(track, stream);
+
+  pc.addEventListener("icecandidate", (e) => {
+    if (e.candidate) {
+      state.ws.send(
+        JSON.stringify({
+          type: "signal",
+          payload: { kind: "ice", candidate: e.candidate },
+        })
+      );
+    }
+  });
+
+  pc.addEventListener("datachannel", (e) => {
+    if (e.channel.label === "input") wireInputChannel(e.channel);
+  });
+
+  const offer = await pc.createOffer();
+  await pc.setLocalDescription(offer);
+  state.ws.send(
+    JSON.stringify({
+      type: "signal",
+      payload: { kind: "sdp", sdp: pc.localDescription },
+    })
+  );
+}
+
+async function handleWebRTCSignal(payload) {
+  if (!state.pc) return;
+  if (payload.kind === "sdp") {
+    await state.pc.setRemoteDescription(payload.sdp);
+    if (payload.sdp.type === "offer") {
+      const ans = await state.pc.createAnswer();
+      await state.pc.setLocalDescription(ans);
+      state.ws.send(
+        JSON.stringify({
+          type: "signal",
+          payload: { kind: "sdp", sdp: state.pc.localDescription },
+        })
+      );
+    }
+  } else if (payload.kind === "ice") {
+    try {
+      await state.pc.addIceCandidate(payload.candidate);
+    } catch (err) {
+      console.warn("addIceCandidate failed", err);
+    }
+  }
+}
+
+function wireInputChannel(ch) {
+  state.inputChannel = ch;
+  ch.addEventListener("message", async (evt) => {
+    let event;
+    try {
+      event = JSON.parse(evt.data);
+    } catch {
+      return;
+    }
+    await window.hostAPI.inject(event);
+  });
+}
+
+function teardownPeer() {
+  if (state.pc) {
+    try { state.pc.close(); } catch {}
+    state.pc = null;
+  }
+  if (state.screenStream) {
+    for (const t of state.screenStream.getTracks()) t.stop();
+    state.screenStream = null;
+  }
+  state.inputChannel = null;
+  state.pendingViewer = null;
+}
+
+boot().catch((err) => {
+  console.error(err);
+  setStatus("Startup failed: " + err.message);
+});

--- a/remote-desktop/shared/protocol.md
+++ b/remote-desktop/shared/protocol.md
@@ -1,0 +1,55 @@
+# Wire protocol
+
+All messages are JSON, sent over WebSocket (signaling) or the WebRTC data
+channel (input events). Keep this file in sync with `signaling/server.js`,
+`host/src/main.js`, and `viewer/src/renderer.js`.
+
+## Signaling (WebSocket)
+
+### Host -> server
+
+- `{ type: "host-register", passcodeHash }`
+  - `passcodeHash` = SHA-256 hex of the session passcode. Plaintext never
+    leaves the host.
+- `{ type: "host-decision", accept: boolean }`
+  - Sent after the host UI displays the Accept / Reject dialog.
+- `{ type: "signal", payload }`
+  - Opaque WebRTC SDP / ICE payload, forwarded to the paired viewer.
+- `{ type: "end-session" }`
+
+### Viewer -> server
+
+- `{ type: "viewer-connect", sessionId, passcodeHash, viewerLabel }`
+- `{ type: "signal", payload }`
+- `{ type: "end-session" }`
+
+### Server -> host
+
+- `{ type: "host-registered", sessionId }`
+- `{ type: "join-request", viewerNonce, viewerLabel }`
+- `{ type: "viewer-disconnected" }`
+- `{ type: "signal", payload }`
+- `{ type: "session-closed", reason }`
+- `{ type: "error", error }`
+
+### Server -> viewer
+
+- `{ type: "awaiting-approval" }`
+- `{ type: "approved" }`
+- `{ type: "rejected" }`
+- `{ type: "signal", payload }`
+- `{ type: "session-closed", reason }`
+- `{ type: "error", error }`
+
+## Input channel (WebRTC data channel, label = "input")
+
+Viewer -> host only. Host ignores messages sent in the other direction.
+
+- `{ type: "mouse-move", xNorm, yNorm }`
+  - `xNorm`, `yNorm` in `[0, 1]` relative to the captured display.
+- `{ type: "mouse-button", button: "left" | "right" | "middle", state: "down" | "up" }`
+- `{ type: "mouse-wheel", dx, dy }`
+- `{ type: "key", code, state: "down" | "up" }`
+  - `code` is a KeyboardEvent `code` value (e.g. `KeyA`, `Enter`, `ShiftLeft`).
+- `{ type: "text", value }`
+  - Fallback for IME / paste; host types the string literally.

--- a/remote-desktop/signaling/package.json
+++ b/remote-desktop/signaling/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "remote-desktop-signaling",
+  "version": "0.1.0",
+  "description": "WebSocket signaling server that brokers WebRTC handshakes between a host and a viewer by session ID.",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/remote-desktop/signaling/server.js
+++ b/remote-desktop/signaling/server.js
@@ -1,0 +1,141 @@
+import { WebSocketServer } from "ws";
+import { randomBytes } from "node:crypto";
+
+const PORT = Number(process.env.PORT || 8443);
+
+// sessionId -> { hostSocket, viewerSocket, passcodeHash, createdAt }
+const sessions = new Map();
+
+function newSessionId() {
+  // 9 digits, grouped like "123 456 789" when displayed by the host UI.
+  let id = "";
+  for (let i = 0; i < 9; i++) id += Math.floor(Math.random() * 10);
+  // Avoid collisions by regenerating if already in use.
+  if (sessions.has(id)) return newSessionId();
+  return id;
+}
+
+function send(ws, msg) {
+  if (ws && ws.readyState === ws.OPEN) ws.send(JSON.stringify(msg));
+}
+
+function closeSession(sessionId, reason) {
+  const s = sessions.get(sessionId);
+  if (!s) return;
+  send(s.hostSocket, { type: "session-closed", reason });
+  send(s.viewerSocket, { type: "session-closed", reason });
+  sessions.delete(sessionId);
+}
+
+const wss = new WebSocketServer({ port: PORT });
+console.log(`[signaling] listening on ws://0.0.0.0:${PORT}`);
+
+wss.on("connection", (ws) => {
+  ws.role = null;
+  ws.sessionId = null;
+
+  ws.on("message", (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return send(ws, { type: "error", error: "invalid-json" });
+    }
+
+    switch (msg.type) {
+      case "host-register": {
+        // Host asks the server to allocate a new session id.
+        // Passcode is generated client-side by the host and only its hash
+        // is sent here — the server never sees the plaintext passcode.
+        if (!msg.passcodeHash || typeof msg.passcodeHash !== "string") {
+          return send(ws, { type: "error", error: "missing-passcode-hash" });
+        }
+        const sessionId = newSessionId();
+        sessions.set(sessionId, {
+          hostSocket: ws,
+          viewerSocket: null,
+          passcodeHash: msg.passcodeHash,
+          createdAt: Date.now(),
+        });
+        ws.role = "host";
+        ws.sessionId = sessionId;
+        send(ws, { type: "host-registered", sessionId });
+        console.log(`[signaling] host registered session=${sessionId}`);
+        break;
+      }
+
+      case "viewer-connect": {
+        // Viewer supplies session id + passcode hash; if they match, we
+        // forward a join-request to the host for explicit approval.
+        const s = sessions.get(msg.sessionId);
+        if (!s) return send(ws, { type: "error", error: "unknown-session" });
+        if (s.viewerSocket) {
+          return send(ws, { type: "error", error: "session-busy" });
+        }
+        if (msg.passcodeHash !== s.passcodeHash) {
+          return send(ws, { type: "error", error: "bad-passcode" });
+        }
+        s.viewerSocket = ws;
+        ws.role = "viewer";
+        ws.sessionId = msg.sessionId;
+        const viewerNonce = randomBytes(4).toString("hex");
+        ws.viewerNonce = viewerNonce;
+        send(s.hostSocket, {
+          type: "join-request",
+          viewerNonce,
+          viewerLabel: msg.viewerLabel || "unknown",
+        });
+        send(ws, { type: "awaiting-approval" });
+        console.log(
+          `[signaling] viewer requested session=${msg.sessionId} nonce=${viewerNonce}`
+        );
+        break;
+      }
+
+      case "host-decision": {
+        // Host accepts or rejects the pending viewer.
+        const s = sessions.get(ws.sessionId);
+        if (!s || ws.role !== "host" || !s.viewerSocket) return;
+        if (msg.accept) {
+          send(s.viewerSocket, { type: "approved" });
+          console.log(`[signaling] session=${ws.sessionId} approved by host`);
+        } else {
+          send(s.viewerSocket, { type: "rejected" });
+          s.viewerSocket = null;
+          console.log(`[signaling] session=${ws.sessionId} rejected by host`);
+        }
+        break;
+      }
+
+      case "signal": {
+        // Relay SDP / ICE between the two paired peers.
+        const s = sessions.get(ws.sessionId);
+        if (!s) return;
+        const peer =
+          ws.role === "host" ? s.viewerSocket : s.hostSocket;
+        send(peer, { type: "signal", payload: msg.payload });
+        break;
+      }
+
+      case "end-session": {
+        closeSession(ws.sessionId, "ended-by-peer");
+        break;
+      }
+
+      default:
+        send(ws, { type: "error", error: "unknown-type" });
+    }
+  });
+
+  ws.on("close", () => {
+    if (!ws.sessionId) return;
+    const s = sessions.get(ws.sessionId);
+    if (!s) return;
+    if (ws.role === "host") {
+      closeSession(ws.sessionId, "host-disconnected");
+    } else if (ws.role === "viewer") {
+      s.viewerSocket = null;
+      send(s.hostSocket, { type: "viewer-disconnected" });
+    }
+  });
+});

--- a/remote-desktop/viewer/package.json
+++ b/remote-desktop/viewer/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "remote-desktop-viewer",
+  "version": "0.1.0",
+  "description": "Viewer app: enter a session ID + passcode, view the host's screen, and send mouse/keyboard input over WebRTC.",
+  "main": "src/main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^33.0.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/remote-desktop/viewer/src/main.js
+++ b/remote-desktop/viewer/src/main.js
@@ -1,0 +1,31 @@
+const { app, BrowserWindow, ipcMain } = require("electron");
+const path = require("node:path");
+const { createHash } = require("node:crypto");
+
+const SIGNALING_URL = process.env.SIGNALING_URL || "ws://localhost:8443";
+
+let mainWindow = null;
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    title: "Remote Desktop Viewer",
+    webPreferences: {
+      preload: path.join(__dirname, "preload.cjs"),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+  mainWindow.loadFile(path.join(__dirname, "renderer.html"));
+}
+
+app.whenReady().then(createWindow);
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") app.quit();
+});
+
+ipcMain.handle("viewer:signaling-url", () => SIGNALING_URL);
+ipcMain.handle("viewer:hash-passcode", (_evt, passcode) =>
+  createHash("sha256").update(String(passcode)).digest("hex")
+);

--- a/remote-desktop/viewer/src/preload.cjs
+++ b/remote-desktop/viewer/src/preload.cjs
@@ -1,0 +1,6 @@
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("viewerAPI", {
+  signalingUrl: () => ipcRenderer.invoke("viewer:signaling-url"),
+  hashPasscode: (passcode) => ipcRenderer.invoke("viewer:hash-passcode", passcode),
+});

--- a/remote-desktop/viewer/src/renderer.html
+++ b/remote-desktop/viewer/src/renderer.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Remote Desktop Viewer</title>
+    <style>
+      :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
+      html, body { margin: 0; height: 100%; }
+      body { display: flex; flex-direction: column; background: #111; color: #eee; }
+      .connect-bar {
+        display: flex; gap: 8px; padding: 10px; background: #222; align-items: center;
+      }
+      .connect-bar input {
+        font-family: ui-monospace, Menlo, Consolas, monospace;
+        font-size: 14px; padding: 6px 8px; border-radius: 4px; border: 1px solid #555;
+        background: #111; color: #eee;
+      }
+      .connect-bar button {
+        padding: 6px 12px; border-radius: 4px; border: 1px solid #3a7; background: #2a7; color: white; cursor: pointer;
+      }
+      .connect-bar button.danger { background: #c33; border-color: #c33; }
+      .connect-bar .status { margin-left: auto; font-size: 12px; opacity: 0.8; }
+      .stage {
+        flex: 1; position: relative; display: flex; align-items: center; justify-content: center;
+      }
+      video {
+        max-width: 100%; max-height: 100%;
+        background: #000;
+        cursor: crosshair;
+      }
+      .placeholder { opacity: 0.6; font-size: 14px; }
+    </style>
+  </head>
+  <body>
+    <div class="connect-bar">
+      <input id="session-id" placeholder="Session ID (9 digits)" maxlength="11" />
+      <input id="passcode" placeholder="Passcode (6 digits)" maxlength="6" />
+      <button id="btn-connect">Connect</button>
+      <button id="btn-disconnect" class="danger" style="display:none">Disconnect</button>
+      <span class="status" id="status">Not connected</span>
+    </div>
+    <div class="stage">
+      <div class="placeholder" id="placeholder">Enter the host's session ID and passcode, then click Connect.</div>
+      <video id="remote-video" autoplay playsinline style="display:none" tabindex="0"></video>
+    </div>
+    <script src="./renderer.js"></script>
+  </body>
+</html>

--- a/remote-desktop/viewer/src/renderer.js
+++ b/remote-desktop/viewer/src/renderer.js
@@ -1,0 +1,192 @@
+// Viewer-side renderer. Owns the WebSocket to the signaling server and the
+// RTCPeerConnection to the host. Captures pointer/keyboard events on the
+// <video> element and forwards them over the "input" data channel, with
+// coordinates normalized to [0, 1] so the host can denormalize against its
+// own screen size.
+
+const $ = (id) => document.getElementById(id);
+
+const state = {
+  ws: null,
+  pc: null,
+  inputChannel: null,
+  connected: false,
+};
+
+const ICE_SERVERS = [{ urls: "stun:stun.l.google.com:19302" }];
+
+function setStatus(text) { $("status").textContent = text; }
+
+$("btn-connect").addEventListener("click", connect);
+$("btn-disconnect").addEventListener("click", disconnect);
+
+async function connect() {
+  const rawId = $("session-id").value.replace(/\D/g, "");
+  const passcode = $("passcode").value.replace(/\D/g, "");
+  if (rawId.length !== 9 || passcode.length !== 6) {
+    setStatus("Enter a 9-digit ID and 6-digit passcode.");
+    return;
+  }
+  const passcodeHash = await window.viewerAPI.hashPasscode(passcode);
+  const url = await window.viewerAPI.signalingUrl();
+
+  const ws = new WebSocket(url);
+  state.ws = ws;
+  setStatus("Connecting to signaling…");
+
+  ws.addEventListener("open", () => {
+    ws.send(
+      JSON.stringify({
+        type: "viewer-connect",
+        sessionId: rawId,
+        passcodeHash,
+        viewerLabel: navigator.userAgent.split(")")[0] + ")",
+      })
+    );
+  });
+
+  ws.addEventListener("message", async (evt) => {
+    const msg = JSON.parse(evt.data);
+    await handleSignal(msg);
+  });
+
+  ws.addEventListener("close", () => {
+    if (!state.connected) setStatus("Signaling closed.");
+  });
+}
+
+async function handleSignal(msg) {
+  switch (msg.type) {
+    case "awaiting-approval":
+      setStatus("Waiting for host to approve…");
+      break;
+    case "approved":
+      setStatus("Approved. Establishing peer connection…");
+      await startPeer();
+      break;
+    case "rejected":
+      setStatus("Host rejected the connection.");
+      state.ws?.close();
+      break;
+    case "signal":
+      await handleWebRTCSignal(msg.payload);
+      break;
+    case "session-closed":
+      setStatus("Session closed: " + msg.reason);
+      disconnect();
+      break;
+    case "error":
+      setStatus("Error: " + msg.error);
+      break;
+  }
+}
+
+async function startPeer() {
+  const pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+  state.pc = pc;
+
+  pc.addEventListener("track", (e) => {
+    const video = $("remote-video");
+    video.srcObject = e.streams[0];
+    video.style.display = "block";
+    $("placeholder").style.display = "none";
+    wireInputCapture(video);
+    $("btn-connect").style.display = "none";
+    $("btn-disconnect").style.display = "inline-block";
+    state.connected = true;
+    setStatus("Connected.");
+  });
+
+  pc.addEventListener("icecandidate", (e) => {
+    if (e.candidate) {
+      state.ws.send(
+        JSON.stringify({
+          type: "signal",
+          payload: { kind: "ice", candidate: e.candidate },
+        })
+      );
+    }
+  });
+
+  // Viewer creates the data channel; host picks it up via `ondatachannel`.
+  const ch = pc.createDataChannel("input", { ordered: true });
+  state.inputChannel = ch;
+}
+
+async function handleWebRTCSignal(payload) {
+  if (!state.pc) return;
+  if (payload.kind === "sdp") {
+    await state.pc.setRemoteDescription(payload.sdp);
+    if (payload.sdp.type === "offer") {
+      const ans = await state.pc.createAnswer();
+      await state.pc.setLocalDescription(ans);
+      state.ws.send(
+        JSON.stringify({
+          type: "signal",
+          payload: { kind: "sdp", sdp: state.pc.localDescription },
+        })
+      );
+    }
+  } else if (payload.kind === "ice") {
+    try { await state.pc.addIceCandidate(payload.candidate); } catch {}
+  }
+}
+
+function sendInput(event) {
+  const ch = state.inputChannel;
+  if (!ch || ch.readyState !== "open") return;
+  ch.send(JSON.stringify(event));
+}
+
+function wireInputCapture(video) {
+  video.addEventListener("mousemove", (e) => {
+    const rect = video.getBoundingClientRect();
+    const xNorm = (e.clientX - rect.left) / rect.width;
+    const yNorm = (e.clientY - rect.top) / rect.height;
+    sendInput({ type: "mouse-move", xNorm, yNorm });
+  });
+
+  const BUTTON = { 0: "left", 1: "middle", 2: "right" };
+  video.addEventListener("mousedown", (e) => {
+    e.preventDefault();
+    video.focus();
+    sendInput({ type: "mouse-button", button: BUTTON[e.button] || "left", state: "down" });
+  });
+  video.addEventListener("mouseup", (e) => {
+    e.preventDefault();
+    sendInput({ type: "mouse-button", button: BUTTON[e.button] || "left", state: "up" });
+  });
+  video.addEventListener("contextmenu", (e) => e.preventDefault());
+  video.addEventListener("wheel", (e) => {
+    e.preventDefault();
+    // Convert pixel-delta to a small "ticks" count for nut-js.
+    sendInput({
+      type: "mouse-wheel",
+      dx: Math.sign(e.deltaX) * Math.min(5, Math.ceil(Math.abs(e.deltaX) / 40)),
+      dy: Math.sign(e.deltaY) * Math.min(5, Math.ceil(Math.abs(e.deltaY) / 40)),
+    });
+  }, { passive: false });
+
+  video.addEventListener("keydown", (e) => {
+    e.preventDefault();
+    sendInput({ type: "key", code: e.code, state: "down" });
+  });
+  video.addEventListener("keyup", (e) => {
+    e.preventDefault();
+    sendInput({ type: "key", code: e.code, state: "up" });
+  });
+}
+
+function disconnect() {
+  if (state.ws) { try { state.ws.send(JSON.stringify({ type: "end-session" })); } catch {} state.ws.close(); state.ws = null; }
+  if (state.pc) { try { state.pc.close(); } catch {} state.pc = null; }
+  const video = $("remote-video");
+  video.srcObject = null;
+  video.style.display = "none";
+  $("placeholder").style.display = "block";
+  $("btn-connect").style.display = "inline-block";
+  $("btn-disconnect").style.display = "none";
+  state.connected = false;
+  state.inputChannel = null;
+  setStatus("Disconnected.");
+}


### PR DESCRIPTION
## Summary

Scaffolds a three-part AnyDesk-style remote desktop tool under `remote-desktop/`:

- **`signaling/`** — Node + `ws` WebSocket server. Pairs a host and viewer by 9-digit session ID and SHA-256 passcode hash. Plaintext passcode never leaves the host.
- **`host/`** — Electron app (Windows). Generates a fresh ID + one-time passcode per session, requires an explicit **Accept** click for every incoming request, shows a persistent red "your screen is being viewed" banner, captures the screen via `desktopCapturer`, and applies remote input via `@nut-tree-fork/nut-js`.
- **`viewer/`** — Electron app. Enter ID + passcode, view the host's screen, click to focus then forward mouse/keyboard events over a WebRTC data channel with normalized coordinates.

Video + input go peer-to-peer over WebRTC (Google STUN). Signaling server only brokers the SDP/ICE handshake.

## Consent model (deliberately baked in)

- No silent mode, no auto-accept, no unattended/always-on.
- Fresh passcode per session; not stored.
- Red on-screen banner + End Session button visible whenever a viewer is connected.
- See `remote-desktop/README.md` §"What's intentionally not here".

## Not included / known limitations

- Windows-only tested.
- No audio, clipboard sync, file transfer, or multi-monitor picker.
- No TURN server (strict NATs will fail).
- UAC-elevated windows won't receive input unless the host app itself is elevated.
- No rate limiting / brute-force protection on the 6-digit passcode — don't expose the signaling server publicly without adding TLS + auth + lockout.

## Test plan

- [ ] `cd remote-desktop/signaling && npm install && npm start` — server starts on `:8443`
- [ ] `cd remote-desktop/host && npm install && npm start` on a Windows 10/11 machine — UI shows session ID + passcode, connects to signaling
- [ ] `cd remote-desktop/viewer && npm install && npm start` — enter ID + passcode, click Connect
- [ ] Host sees "Incoming connection request", clicks Accept → viewer sees the screen
- [ ] Click into the video on viewer side → mouse moves on the host machine
- [ ] Keyboard input on viewer → typing appears on host
- [ ] Host clicks "End session" → viewer disconnects cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2n7Bo3Ua3ssVx26J4tBqU)_